### PR TITLE
Disable Jenkins-X Draft Maven pack application

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+draft.toml
+charts/
+NOTICE
+LICENSE
+README.md

--- a/.helmignore
+++ b/.helmignore
@@ -1,0 +1,27 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+*.png
+
+# known compile time folders
+target/
+node_modules/
+vendor/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,82 @@
+pipeline {
+  agent {
+    label "jenkins-maven"
+  }
+  environment {
+    ORG = 'REPLACE_ME_ORG'
+    APP_NAME = 'REPLACE_ME_APP_NAME'
+    CHARTMUSEUM_CREDS = credentials('jenkins-x-chartmuseum')
+  }
+  stages {
+    stage('CI Build and push snapshot') {
+      when {
+        branch 'PR-*'
+      }
+      environment {
+        PREVIEW_VERSION = "0.0.0-SNAPSHOT-$BRANCH_NAME-$BUILD_NUMBER"
+        PREVIEW_NAMESPACE = "$APP_NAME-$BRANCH_NAME".toLowerCase()
+        HELM_RELEASE = "$PREVIEW_NAMESPACE".toLowerCase()
+      }
+      steps {
+        container('maven') {
+          sh "mvn versions:set -DnewVersion=$PREVIEW_VERSION"
+          sh "mvn install"
+          sh "skaffold version"
+          sh "export VERSION=$PREVIEW_VERSION && skaffold build -f skaffold.yaml"
+          sh "jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION"
+          dir('charts/preview') {
+            sh "make preview"
+            sh "jx preview --app $APP_NAME --dir ../.."
+          }
+        }
+      }
+    }
+    stage('Build Release') {
+      when {
+        branch 'master'
+      }
+      steps {
+        container('maven') {
+
+          // ensure we're not on a detached head
+          sh "git checkout master"
+          sh "git config --global credential.helper store"
+          sh "jx step git credentials"
+
+          // so we can retrieve the version in later steps
+          sh "echo \$(jx-release-version) > VERSION"
+          sh "mvn versions:set -DnewVersion=\$(cat VERSION)"
+          sh "mvn clean install"
+          sh "jx step tag --version \$(cat VERSION)"
+          sh "mvn deploy -DskipTests"
+          sh "skaffold version"
+          sh "export VERSION=`cat VERSION` && skaffold build -f skaffold.yaml"
+          sh "jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION)"
+        }
+      }
+    }
+    stage('Promote to Environments') {
+      when {
+        branch 'master'
+      }
+      steps {
+        container('maven') {
+          dir('charts/REPLACE_ME_APP_NAME') {
+            sh "jx step changelog --version v\$(cat ../../VERSION)"
+
+            // release the helm chart
+            sh "jx step helm release"
+
+            // promote through all 'Auto' promotion Environments
+            sh "jx promote -b --all-auto --timeout 1h --version \$(cat ../../VERSION)"
+          }
+        }
+      }
+    }
+  }
+  post {
+        always {
+          cleanWs()
+        }
+  }
+}

--- a/charts/REPLACE_ME_APP_NAME/Chart.yaml
+++ b/charts/REPLACE_ME_APP_NAME/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-description: A Helm chart for Kubernetes
-icon: https://raw.githubusercontent.com/jenkins-x/jenkins-x-platform/master/images/java.png
+description: A Helm chart for Activiti Cloud Runtime Bundle Example
+icon: "https://salaboy.files.wordpress.com/2018/01/acitiviti_icon_fullcolor_github_400x400.png"
 name: REPLACE_ME_APP_NAME
 version: 0.1.0-SNAPSHOT

--- a/charts/REPLACE_ME_APP_NAME/Chart.yaml
+++ b/charts/REPLACE_ME_APP_NAME/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-description: A Helm chart for Activiti Cloud Runtime Bundle Example
-icon: "https://salaboy.files.wordpress.com/2018/01/acitiviti_icon_fullcolor_github_400x400.png"
+description: A Helm chart for Activiti Cloud Runtime Bundle Quickstart
+icon: https://salaboy.files.wordpress.com/2018/01/acitiviti_icon_fullcolor_github_400x400.png
 name: REPLACE_ME_APP_NAME
 version: 0.1.0-SNAPSHOT

--- a/charts/REPLACE_ME_APP_NAME/README.md
+++ b/charts/REPLACE_ME_APP_NAME/README.md
@@ -1,1 +1,1 @@
-# Java application
+# REPLACE_ME_APP_NAME

--- a/charts/REPLACE_ME_APP_NAME/requirements.yaml
+++ b/charts/REPLACE_ME_APP_NAME/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
-- alias: activitipostgresql
+- alias: REPLACE_ME_APP_NAME-postgresql
   name: postgresql
   repository: https://kubernetes-charts.storage.googleapis.com
   version: 0.11.0
-  condition: application.runtime-bundle.db.deployPostgres,runtime-bundle.db.deployPostgres,db.deployPostgres
+  condition: application.REPLACE_ME_APP_NAME.db.deployPostgres,REPLACE_ME_APP_NAME.db.deployPostgres

--- a/charts/REPLACE_ME_APP_NAME/values.yaml
+++ b/charts/REPLACE_ME_APP_NAME/values.yaml
@@ -18,17 +18,20 @@ global:
       port: 80
 db:
   uri: ""
-  name: activitipostgresql
-  deployPostgres: false
+  name: REPLACE_ME_APP_NAME-postgresql
   port: 5432
 
-activitipostgresql:
+REPLACE_ME_APP_NAME:
+  db:
+    deployPostgres: true
+
+REPLACE_ME_APP_NAME-postgresql:
    postgresPassword: activiti
 
 javaOpts:
-  xmx: 768m
+  xmx: 2048m
   xms: 512m
-  other: -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
+  other: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
 image:
   repository: draft
   tag: dev
@@ -39,14 +42,14 @@ service:
   externalPort: 80
   internalPort: 8080
   annotations:
-    fabric8.io/expose: "true"
+    fabric8.io/expose: "false"
     fabric8.io/ingress.annotations: "kubernetes.io/ingress.class: nginx"
 resources:
   limits:
-    memory: 768Mi
+    memory: 
   requests:
-    cpu: 400m
-    memory: 768Mi
+    cpu: 1024m
+    memory: 512Mi
 probePath: /actuator/health
 livenessProbe:
   initialDelaySeconds: 140

--- a/charts/REPLACE_ME_APP_NAME/values.yaml
+++ b/charts/REPLACE_ME_APP_NAME/values.yaml
@@ -29,8 +29,8 @@ REPLACE_ME_APP_NAME-postgresql:
    postgresPassword: activiti
 
 javaOpts:
-  xmx: 2048m
-  xms: 512m
+  xmx: 1768m
+  xms: 768m
   other: -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90
 image:
   repository: draft
@@ -46,10 +46,10 @@ service:
     fabric8.io/ingress.annotations: "kubernetes.io/ingress.class: nginx"
 resources:
   limits:
-    memory: 
+    memory: 2048Mi
   requests:
     cpu: 1024m
-    memory: 512Mi
+    memory: 1024Mi
 probePath: /actuator/health
 livenessProbe:
   initialDelaySeconds: 140

--- a/charts/preview/Chart.yaml
+++ b/charts/preview/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+description: A Helm chart for Kubernetes
+name: preview
+icon: https://raw.githubusercontent.com/jenkins-x/jenkins-x-platform/master/images/java.png
+version: 0.1.0-SNAPSHOT

--- a/charts/preview/Chart.yaml
+++ b/charts/preview/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: preview
-icon: https://raw.githubusercontent.com/jenkins-x/jenkins-x-platform/master/images/java.png
+icon: https://salaboy.files.wordpress.com/2018/01/acitiviti_icon_fullcolor_github_400x400.png
 version: 0.1.0-SNAPSHOT

--- a/charts/preview/Makefile
+++ b/charts/preview/Makefile
@@ -1,0 +1,18 @@
+OS := $(shell uname)
+
+preview: 
+ifeq ($(OS),Darwin)
+	sed -i "" -e "s/version:.*/version: $(PREVIEW_VERSION)/" Chart.yaml
+	sed -i "" -e "s/version:.*/version: $(PREVIEW_VERSION)/" ../*/Chart.yaml
+	sed -i "" -e "s/tag:.*/tag: $(PREVIEW_VERSION)/" values.yaml
+else ifeq ($(OS),Linux)
+	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" Chart.yaml
+	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" ../*/Chart.yaml
+	sed -i -e "s|repository:.*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_ORG\/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s/tag:.*/tag: $(PREVIEW_VERSION)/" values.yaml
+else
+	echo "platfrom $(OS) not supported to release from"
+	exit -1
+endif
+	echo "  version: $(PREVIEW_VERSION)" >> requirements.yaml
+	jx step helm build

--- a/charts/preview/requirements.yaml
+++ b/charts/preview/requirements.yaml
@@ -1,0 +1,16 @@
+# !! File must end with empty line !!
+dependencies:
+- alias: expose
+  name: exposecontroller
+  repository: http://chartmuseum.jenkins-x.io
+  version: 2.3.91
+- alias: cleanup
+  name: exposecontroller
+  repository: http://chartmuseum.jenkins-x.io
+  version: 2.3.91
+
+  # !! "alias: preview" must be last entry in dependencies array !!
+  # !! Place custom dependencies above !!
+- alias: preview
+  name: REPLACE_ME_APP_NAME
+  repository: file://../REPLACE_ME_APP_NAME

--- a/charts/preview/values.yaml
+++ b/charts/preview/values.yaml
@@ -1,0 +1,22 @@
+
+expose:
+  Annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: hook-succeeded
+  config:
+    exposer: Ingress
+    http: true
+    tlsacme: false
+
+cleanup:
+  Args:
+    - --cleanup
+  Annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: hook-succeeded
+
+preview:
+  image:
+    repository:
+    tag:
+    pullPolicy: IfNotPresent

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,0 +1,30 @@
+apiVersion: skaffold/v1beta2
+kind: Config
+build:
+  artifacts:
+  - image: changeme
+    context: .
+    docker: {}
+  tagPolicy:
+    envTemplate:
+      template: '{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}'
+  local: {}
+deploy:
+  kubectl: {}
+profiles:
+- name: dev
+  build:
+    artifacts:
+    - docker: {}
+    tagPolicy:
+      envTemplate:
+        template: '{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}'
+    local: {}
+  deploy:
+    helm:
+      releases:
+      - name: REPLACE_ME_APP_NAME
+        chartPath: charts/REPLACE_ME_APP_NAME
+        setValueTemplates:
+          image.repository: '{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME'
+          image.tag: '{{.DIGEST_HEX}}'

--- a/watch.sh
+++ b/watch.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# watch the java files and continously deploy the service
+mvn clean install
+skaffold run -p dev
+reflex -r "\.java$" -- bash -c 'mvn install && skaffold run -p dev'


### PR DESCRIPTION
This PR removes Jenkins-X draft pack apply step that creates `charts/maven` folder and causes problems with tagging wrong Helm chart in the pipeline run. 

Other Changes:

* fix: parameterize Postgresql deployment template scope, values and requirements 
* fix: add Activiti icon and description to Chart.yaml
* fix: update default memory and cpu request values
* fix: add README.md placeholder template

