### PR TITLE
fix: change base Docker image to adoptopenjdk/openjdk11:jdk-11.0.2.7-alpine-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM adoptopenjdk/openjdk11:jdk-11.0.2.7-alpine-slim
+# Install the font required for runtime bundle BPMN diagram renderer. This will be removed later
+RUN apk --update add fontconfig ttf-dejavu msttcorefonts-installer fontconfig update-ms-fonts fc-cache -f
 ENV PORT 8080
 EXPOSE 8080
 COPY target/*.jar /opt/app.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM openjdk:11-jdk-slim
+FROM adoptopenjdk/openjdk11:jdk-11.0.2.7-alpine-slim
 ENV PORT 8080
 EXPOSE 8080
 COPY target/*.jar /opt/app.jar
 WORKDIR /opt
-ENTRYPOINT exec java $JAVA_OPTS -jar app.jar
+ENTRYPOINT ["sh","-c", "java $JAVA_OPTS -jar app.jar"]
 


### PR DESCRIPTION
This PR fixes Docker image security vulnerabilities reported by Google Container Analysis API when using Openjdk base images. Using adoptopenjdk base image resolves the issue.

![image](https://user-images.githubusercontent.com/20428629/52975339-f40c0a80-3379-11e9-9c99-bb5047c175ad.png)
